### PR TITLE
Fixed link to gwt-charts jar.

### DIFF
--- a/src/main/java/gwt/material/design/demo/client/application/charts/ChartsView.ui.xml
+++ b/src/main/java/gwt/material/design/demo/client/application/charts/ChartsView.ui.xml
@@ -25,8 +25,8 @@
              xmlns:demo="urn:import:gwt.material.design.demo.client.ui">
 
   <g:HTMLPanel>
-    <m:MaterialTitle title="Pre-requisites" description="First of all, you must download the gwt-charts 0.9.9.jar for the integration to GWT Material"/>
-    <m:MaterialLink href="http://gwt-charts.googlecode.com/svn/download/gwt-charts-0.9.9.jar" text="Download gwt-charts.jar here" textColor="blue"/>
+    <m:MaterialTitle title="Pre-requisites" description="First of all, you must download the gwt-charts 0.9.10.jar for the integration to GWT Material"/>
+    <m:MaterialLink href="https://mvnrepository.com/artifact/com.googlecode.gwt-charts/gwt-charts" target="_blank" text="Download gwt-charts.jar here" textColor="blue"/>
 
     <m:MaterialTitle title="Setup" description="After downloading the jar, You will have to configure your App.gwt.xml file to inherit the Gwt Charts library. You can do it like this: "/>
 


### PR DESCRIPTION
Is there any reason the link was to 9.9 version, not the latest? I have not tested it with gwt-charts 0.9.10, but I assume there should be no problems.
