### PR TITLE
Fix Broken link at StandardDataTablePresenter

### DIFF
--- a/src/main/java/gwt/material/design/demo/client/application/datatable/standard/StandardDataTablePresenter.java
+++ b/src/main/java/gwt/material/design/demo/client/application/datatable/standard/StandardDataTablePresenter.java
@@ -52,7 +52,7 @@ public class StandardDataTablePresenter extends Presenter<StandardDataTablePrese
     @Override
     protected void onReveal() {
         super.onReveal();
-        SetPageTitleEvent.fire("Standard Data Table", "Data tables display sets of raw data. They usually appear in desktop enterprise products.", "datatable/StandardDataTableView", "https://material.io/guidelines/components/data-tables.html", this);
+        SetPageTitleEvent.fire("Standard Data Table", "Data tables display sets of raw data. They usually appear in desktop enterprise products.", "datatable/standard/StandardDataTableView", "https://material.io/guidelines/components/data-tables.html", this);
     }
 }
 


### PR DESCRIPTION
**Problems**: Broken link

**Reason**: Incomplete path "datatable/StandardDataTableView"

**Solution**: "datatable/standard/StandardDataTableView"

**More: how to replicate**
* Go to broken link at https://gwtmaterialdesign.github.io/gwt-material-demo/#standard_datatable
* On Top of page click at "J Java"